### PR TITLE
Fix similarity calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ begin
     documents.id,
     documents.content,
     documents.url,
-    (documents.embedding <=> query_embedding) as similarity
+    1 - (documents.embedding <=> query_embedding) as similarity
   from documents
-  where (documents.embedding <=> query_embedding) > similarity_threshold
+  where 1 - (documents.embedding <=> query_embedding) > similarity_threshold
   order by documents.embedding <=> query_embedding
   limit match_count;
 end;


### PR DESCRIPTION
Hey, thanks for this project!

`<=>` returns cosine distance (instead of similarity), so this updates the query to account for it.